### PR TITLE
fix: export std vector of Analog and Digital raw_io types

### DIFF
--- a/raw_io.orogen
+++ b/raw_io.orogen
@@ -7,3 +7,4 @@ import_types_from "raw_io/Analog.hpp"
 import_types_from "raw_io/Digital.hpp"
 
 typekit.export_types "raw_io/Analog", "raw_io/Digital"
+typekit.export_types "/std/vector<raw_io/Analog>", "/std/vector<raw_io/Digital>"


### PR DESCRIPTION
This PR adds exports for std/vector types for both analog and digital signals. This enables their usage across different modules without the need for redefinition.