### PR TITLE
fix: export types for std vector Analog and Digital

### DIFF
--- a/raw_io.orogen
+++ b/raw_io.orogen
@@ -7,3 +7,4 @@ import_types_from "raw_io/Analog.hpp"
 import_types_from "raw_io/Digital.hpp"
 
 typekit.export_types "raw_io/Analog", "raw_io/Digital"
+typekit.export_types "/std/vector<raw_io/Analog>", "/std/vector<raw_io/Digital>"


### PR DESCRIPTION
Hijacking https://github.com/rock-drivers/drivers-orogen-raw_io/pull/1 as @kapeps is not available for some days.